### PR TITLE
Add: Publishing a port

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,6 +51,11 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [3000, 6006],
 
+  // Publishing a port
+  // https://code.visualstudio.com/docs/remote/containers#_publishing-a-port
+  // Unlike forwardPorts, these listen on all interfaces (0.0.0.0) not just localhost for it to be available externally
+  // "appPort": ["3000:3000"],
+
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "npm i",
 


### PR DESCRIPTION
https://code.visualstudio.com/docs/remote/containers#_publishing-a-port
Unlike forwardPorts, these listen on all interfaces (0.0.0.0) not just localhost